### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
   },
   "homepage": "https://github.com/hoodiehq/hoodie-client-log#readme",
   "dependencies": {
-    "browser-supports-log-styles": "^1.1.3"
+    "browser-supports-log-styles": "1.1.3"
   },
   "devDependencies": {
-    "browserify": "^11.2.0",
-    "istanbul": "^0.3.18",
-    "istanbul-coveralls": "^1.0.1",
-    "mkdirp": "^0.5.1",
-    "rimraf": "^2.4.3",
+    "browserify": "11.2.0",
+    "istanbul": "0.3.21",
+    "istanbul-coveralls": "1.0.3",
+    "mkdirp": "0.5.1",
+    "rimraf": "2.4.3",
     "semantic-release": "^6.0.3",
-    "standard": "^5.3.0",
-    "tap-spec": "^4.1.0",
-    "tape": "^4.2.0",
-    "uglify-js": "^2.4.24"
+    "standard": "5.3.1",
+    "tap-spec": "4.1.0",
+    "tape": "4.2.0",
+    "uglify-js": "2.4.24"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:
