### PR TITLE
Migration to new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# hoodie-client-log
+# hoodie-log
 
 > Custom log API for the browser
 
-[![Build Status](https://travis-ci.org/hoodiehq/hoodie-client-log.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-client-log)
-[![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-client-log/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-client-log?branch=master)
-[![Dependency Status](https://david-dm.org/hoodiehq/hoodie-client-log.svg)](https://david-dm.org/hoodiehq/hoodie-client-log)
-[![devDependency Status](https://david-dm.org/hoodiehq/hoodie-client-log/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie-client-log#info=devDependencies)
+[![Build Status](https://travis-ci.org/hoodiehq/hoodie-log.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-log)
+[![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-log/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-log?branch=master)
+[![Dependency Status](https://david-dm.org/hoodiehq/hoodie-log.svg)](https://david-dm.org/hoodiehq/hoodie-log)
+[![devDependency Status](https://david-dm.org/hoodiehq/hoodie-log/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie-log#info=devDependencies)
 
-`hoodie-client-log` is a standalone JavaScript library for logging to the
+`hoodie-log` is a standalone JavaScript library for logging to the
 browser console. If available, it takes advantage of [CSS-based styling of console
 log outputs](https://developer.mozilla.org/en-US/docs/Web/API/Console#Styling_console_output).
 
@@ -311,8 +311,8 @@ fooLog('baz!')
 Local setup
 
 ```
-git clone git@github.com:hoodiehq/hoodie-client-log.git
-cd hoodie-client-log
+git clone git@github.com:hoodiehq/hoodie-log.git
+cd hoodie-log
 npm install
 ```
 

--- a/client/index.js
+++ b/client/index.js
@@ -2,13 +2,13 @@ module.exports = Log
 
 Log.console = console
 
-var log = require('./lib/log')
-var debug = require('./lib/debug')
-var info = require('./lib/info')
-var warn = require('./lib/warn')
-var error = require('./lib/error')
+var log = require('../lib/log')
+var debug = require('../lib/debug')
+var info = require('../lib/info')
+var warn = require('../lib/warn')
+var error = require('../lib/error')
 
-var parseOptions = require('./lib/utils/parse-options')
+var parseOptions = require('../lib/utils/parse-options')
 
 function Log (options) {
   var state = parseOptions(options)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hoodie-client-log",
   "description": "log API for the browser",
   "main": "client/index.js",
+  "browser": "client/index.js",
   "scripts": {
     "prebuild": "rimraf dist && mkdirp dist",
     "build": "browserify client/index.js --standalone=Log > dist/hoodie-client-log.js",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "hoodie-client-log",
   "description": "log API for the browser",
-  "main": "index.js",
+  "main": "client/index.js",
   "scripts": {
     "prebuild": "rimraf dist && mkdirp dist",
-    "build": "browserify index.js --standalone=Log > dist/hoodie-client-log.js",
+    "build": "browserify client/index.js --standalone=Log > dist/hoodie-client-log.js",
     "postbuild": "uglifyjs dist/hoodie-client-log.js -mc > dist/hoodie-client-log.min.js",
     "pretest": "standard",
     "test": "npm run -s test:node | tap-spec",
     "test:node": "node tests",
-    "test:watch": "gaze 'clear && node tests | tap-min' 'tests/**/*.js' 'index.js' 'lib/**/*.js'",
+    "test:watch": "gaze 'clear && node tests | tap-min' 'tests/**/*.js' 'client/*.js' 'lib/**/*.js'",
     "test:coverage": "istanbul cover tests",
     "test:coverage:upload": "istanbul-coveralls",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",
     "uglify-js": "^2.6.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "browser": "client/index.js",
   "scripts": {
     "prebuild": "rimraf dist && mkdirp dist",
-    "build": "browserify client/index.js --standalone=Log > dist/hoodie-client-log.js",
-    "postbuild": "uglifyjs dist/hoodie-client-log.js -mc > dist/hoodie-client-log.min.js",
+    "build": "browserify client/index.js --standalone=Log > dist/hoodie-log.js",
+    "postbuild": "uglifyjs dist/hoodie-log.js -mc > dist/hoodie-log.min.js",
     "pretest": "standard",
     "test": "npm run -s test:node | tap-spec",
     "test:node": "node tests",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hoodiehq/hoodie-client-log.git"
+    "url": "https://github.com/hoodiehq/hoodie-log.git"
   },
   "keywords": [
     "hoodie",
@@ -27,9 +27,9 @@
   "author": "The Hoodie Community",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/hoodiehq/hoodie-client-log/issues"
+    "url": "https://github.com/hoodiehq/hoodie-log/issues"
   },
-  "homepage": "https://github.com/hoodiehq/hoodie-client-log#readme",
+  "homepage": "https://github.com/hoodiehq/hoodie-log#readme",
   "dependencies": {
     "browser-supports-log-styles": "^1.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hoodie-client-log",
+  "name": "@hoodie/log",
   "description": "log API for the browser",
   "main": "client/index.js",
   "browser": "client/index.js",

--- a/tests/specs/constructor.js
+++ b/tests/specs/constructor.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 
-var Log = require('../../index')
+var Log = require('../../client')
 
 test('Constructor', function (t) {
   var log = new Log('foo')

--- a/tests/specs/level.js
+++ b/tests/specs/level.js
@@ -1,7 +1,7 @@
 var simple = require('simple-mock')
 var test = require('tape')
 
-var Log = require('../../index')
+var Log = require('../../client')
 
 test('log.level', function (t) {
   Log.console = {

--- a/tests/specs/log.js
+++ b/tests/specs/log.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var simple = require('simple-mock')
-var Log = require('../../index')
+var Log = require('../../client')
 var log = require('../../lib/log')
 
 test('log("bar")', function (t) {

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 
-var Log = require('../../index')
+var Log = require('../../client')
 
 test('log.scoped("bar").info("baz")', function (t) {
   var log = new Log({


### PR DESCRIPTION
PR for #31

I am assuming that all the those services like travis, coveralls and david will work with the new slug after renaming the repository.

I wasn't sure if `"main": "client/index.js"` should stay in the `package.json`. Possibly not because if this module had a server part it would be `server/index.js` I suppose.
